### PR TITLE
feature/BCE-035-fix-base-activity-and-fragment

### DIFF
--- a/app/src/main/java/com/teame/boostcamp/myapplication/ui/CheckListCreateFragment.java
+++ b/app/src/main/java/com/teame/boostcamp/myapplication/ui/CheckListCreateFragment.java
@@ -18,11 +18,6 @@ public class CheckListCreateFragment extends BaseFragment<FragmentCheckListCreat
         return null;
     }
 
-    @Override
-    protected String getClassName() {
-        return "CheckListCreateFragment";
-    }
-
     @Deprecated
     public CheckListCreateFragment() {
         // 기본 생성자는 쓰지 말것 (new Instance 사용)

--- a/app/src/main/java/com/teame/boostcamp/myapplication/ui/MainActivity.java
+++ b/app/src/main/java/com/teame/boostcamp/myapplication/ui/MainActivity.java
@@ -19,11 +19,6 @@ public class MainActivity extends BaseActivity<ActivityMainBinding> {
     }
 
     @Override
-    protected String getClassName() {
-        return "MainActivity";
-    }
-
-    @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         binding.bnvMainNavigation.setOnNavigationItemSelectedListener(onNavigationItemSelectedListener);

--- a/app/src/main/java/com/teame/boostcamp/myapplication/ui/MyListFragment.java
+++ b/app/src/main/java/com/teame/boostcamp/myapplication/ui/MyListFragment.java
@@ -18,11 +18,6 @@ public class MyListFragment extends BaseFragment<FragmentMyListBinding, MyListCo
         return null;
     }
 
-    @Override
-    protected String getClassName() {
-        return "MyListFragment";
-    }
-
     @Deprecated
     public MyListFragment() {
         // 기본 생성자는 쓰지 말것 (new Instance 사용)

--- a/app/src/main/java/com/teame/boostcamp/myapplication/ui/SNSFragment.java
+++ b/app/src/main/java/com/teame/boostcamp/myapplication/ui/SNSFragment.java
@@ -28,12 +28,6 @@ public class SNSFragment extends BaseFragment<FragmentSnsBinding, SNSContract.Pr
         return null;
     }
 
-    @Override
-    protected String getClassName() {
-        return "SNSFragment";
-    }
-
-
     @Deprecated
     public SNSFragment() {
         // 기본 생성자는 쓰지 말것 (new Instance 사용)

--- a/app/src/main/java/com/teame/boostcamp/myapplication/ui/base/BaseActivity.java
+++ b/app/src/main/java/com/teame/boostcamp/myapplication/ui/base/BaseActivity.java
@@ -15,45 +15,44 @@ public abstract class BaseActivity<V extends ViewDataBinding> extends AppCompatA
     // Databinding을 BaseActivity에서 처리하기 위한 추상클래스
     protected abstract int getLayoutResourceId();
 
-    protected abstract String getClassName();
     // BaseActivity를 상속하면 binding과 presenter는 상단의 추상클레스만 구현하면 사용 가능.
     protected V binding;
 
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
-        DLogUtil.i(getClassName()+"::onCreate");
+        DLogUtil.i(getClass().getSimpleName()+"::onCreate");
         super.onCreate(savedInstanceState);
         binding = DataBindingUtil.setContentView(this, getLayoutResourceId());
     }
 
     @Override
     protected void onStart() {
-        DLogUtil.i(getClassName()+"::onStart");
+        DLogUtil.i(getClass().getSimpleName()+"::onStart");
         super.onStart();
     }
 
     @Override
     protected void onResume() {
-        DLogUtil.i(getClassName()+"::onResume");
+        DLogUtil.i(getClass().getSimpleName()+"::onResume");
         super.onResume();
     }
 
     @Override
     protected void onStop() {
-        DLogUtil.i(getClassName()+"::onStop");
+        DLogUtil.i(getClass().getSimpleName()+"::onStop");
         super.onStop();
     }
 
     @Override
     protected void onDestroy() {
-        DLogUtil.i(getClassName()+"::onDestroy");
+        DLogUtil.i(getClass().getSimpleName()+"::onDestroy");
         super.onDestroy();
     }
 
     @Override
     protected void onRestart() {
-        DLogUtil.i(getClassName()+"::onRestart");
+        DLogUtil.i(getClass().getSimpleName()+"::onRestart");
         super.onRestart();
     }
 

--- a/app/src/main/java/com/teame/boostcamp/myapplication/ui/base/BaseFragment.java
+++ b/app/src/main/java/com/teame/boostcamp/myapplication/ui/base/BaseFragment.java
@@ -48,6 +48,7 @@ public abstract class BaseFragment<V extends ViewDataBinding, P extends BasePres
         DLogUtil.i(getClass().getSimpleName()+"::onCreateView");
         binding = DataBindingUtil.inflate(inflater, getLayoutResourceId(), container, false);
         View view = binding.getRoot();
+        presenter = getPresenter();
         return view;
     }
 

--- a/app/src/main/java/com/teame/boostcamp/myapplication/ui/base/BaseFragment.java
+++ b/app/src/main/java/com/teame/boostcamp/myapplication/ui/base/BaseFragment.java
@@ -21,7 +21,6 @@ public abstract class BaseFragment<V extends ViewDataBinding, P extends BasePres
     // View에 바인드될 Presenter를 받아오기 위한 추상클레스
     protected abstract P getPresenter();
 
-    protected abstract String getClassName();
     // BaseActivity를 상속하면 binding과 presenter는 상단의 추상클레스만 구현하면 사용 가능.
     protected V binding;
     protected P presenter;
@@ -39,14 +38,14 @@ public abstract class BaseFragment<V extends ViewDataBinding, P extends BasePres
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
-        DLogUtil.i(getClassName()+"::onCreate");
+        DLogUtil.i(getClass().getSimpleName()+"::onCreate");
         super.onCreate(savedInstanceState);
     }
 
     @Nullable
     @Override
     public View onCreateView(@NonNull LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
-        DLogUtil.i(getClassName()+"::onCreateView");
+        DLogUtil.i(getClass().getSimpleName()+"::onCreateView");
         binding = DataBindingUtil.inflate(inflater, getLayoutResourceId(), container, false);
         View view = binding.getRoot();
         return view;
@@ -55,43 +54,43 @@ public abstract class BaseFragment<V extends ViewDataBinding, P extends BasePres
 
     @Override
     public void onStart() {
-        DLogUtil.i(getClassName()+"::onStart");
+        DLogUtil.i(getClass().getSimpleName()+"::onStart");
         super.onStart();
     }
 
     @Override
     public void onResume() {
-        DLogUtil.i(getClassName()+"::onResume");
+        DLogUtil.i(getClass().getSimpleName()+"::onResume");
         super.onResume();
     }
 
     @Override
     public void onPause() {
-        DLogUtil.i(getClassName()+"::onPause");
+        DLogUtil.i(getClass().getSimpleName()+"::onPause");
         super.onPause();
     }
 
     @Override
     public void onStop() {
-        DLogUtil.i(getClassName()+"::onStop");
+        DLogUtil.i(getClass().getSimpleName()+"::onStop");
         super.onStop();
     }
 
     @Override
     public void onDestroyView() {
-        DLogUtil.i(getClassName()+"::onDestroyView");
+        DLogUtil.i(getClass().getSimpleName()+"::onDestroyView");
         super.onDestroyView();
     }
 
     @Override
     public void onDestroy() {
-        DLogUtil.i(getClassName()+"::onDestroy");
+        DLogUtil.i(getClass().getSimpleName()+"::onDestroy");
         super.onDestroy();
     }
 
     @Override
     public void onDetach() {
-        DLogUtil.i(getClassName()+"::onDetach");
+        DLogUtil.i(getClass().getSimpleName()+"::onDetach");
         super.onDetach();
     }
 

--- a/app/src/main/java/com/teame/boostcamp/myapplication/ui/base/BaseMVPActivity.java
+++ b/app/src/main/java/com/teame/boostcamp/myapplication/ui/base/BaseMVPActivity.java
@@ -20,7 +20,7 @@ public abstract class BaseMVPActivity <V extends ViewDataBinding,P extends BaseP
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
-        DLogUtil.i(getClassName()+"::onCreate");
+        DLogUtil.i(getClass().getSimpleName()+"::onCreate");
         super.onCreate(savedInstanceState);
         presenter = getPresenter();
     }

--- a/app/src/main/java/com/teame/boostcamp/myapplication/ui/createlist/CreateListActivity.java
+++ b/app/src/main/java/com/teame/boostcamp/myapplication/ui/createlist/CreateListActivity.java
@@ -20,11 +20,6 @@ public class CreateListActivity extends BaseMVPActivity<ActivityCreateListBindin
         return R.layout.activity_create_list;
     }
 
-    @Override
-    protected String getClassName() {
-        return "CreateListActivity";
-    }
-
     public static void startActivity(Context context) {
         Intent intent = new Intent(context, CreateListActivity.class);
         context.startActivity(intent);

--- a/app/src/main/java/com/teame/boostcamp/myapplication/ui/example/ExampleActivity.java
+++ b/app/src/main/java/com/teame/boostcamp/myapplication/ui/example/ExampleActivity.java
@@ -30,16 +30,6 @@ public class ExampleActivity extends BaseMVPActivity<ActivityMainBinding, Exampl
         return new ExamplePresenter(this, resourceProvider);
     }
 
-    /**
-     * 생명주기 로그를 위해 BaseActivity에 현재 Activity이름을 알리기위해 구현 (필요없다면 return null)
-     *
-     * @return String
-     */
-    @Override
-    protected String getClassName() {
-        return "ExampleActivity";
-    }
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);

--- a/app/src/main/java/com/teame/boostcamp/myapplication/ui/itemdetail/ItemDetailActivity.java
+++ b/app/src/main/java/com/teame/boostcamp/myapplication/ui/itemdetail/ItemDetailActivity.java
@@ -23,11 +23,6 @@ public class ItemDetailActivity extends BaseMVPActivity<ActivityItemDetailBindin
     }
 
     @Override
-    protected String getClassName() {
-        return null;
-    }
-
-    @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
     }

--- a/app/src/main/java/com/teame/boostcamp/myapplication/ui/login/LoginActivity.java
+++ b/app/src/main/java/com/teame/boostcamp/myapplication/ui/login/LoginActivity.java
@@ -19,11 +19,6 @@ public class LoginActivity extends BaseMVPActivity<ActivityLoginBinding, LoginCo
     }
 
     @Override
-    protected String getClassName() {
-        return "LoginActivity";
-    }
-
-    @Override
     protected LoginContract.Presenter getPresenter() {
         return new LoginPresenter(this, FirebaseAuth.getInstance());
     }

--- a/app/src/main/java/com/teame/boostcamp/myapplication/ui/signup/SignUpActivity.java
+++ b/app/src/main/java/com/teame/boostcamp/myapplication/ui/signup/SignUpActivity.java
@@ -29,11 +29,6 @@ public class SignUpActivity extends BaseMVPActivity<ActivitySignupBinding, SignU
     }
 
     @Override
-    protected String getClassName() {
-        return "SignUpActivity";
-    }
-
-    @Override
     public void setPresenter(Object presenter) {
 
     }

--- a/app/src/main/java/com/teame/boostcamp/myapplication/ui/tabmypost/TabMyPostFragment.java
+++ b/app/src/main/java/com/teame/boostcamp/myapplication/ui/tabmypost/TabMyPostFragment.java
@@ -18,11 +18,6 @@ public class TabMyPostFragment extends BaseFragment<FragmentTabMypostBinding, Ta
         return null;
     }
 
-    @Override
-    protected String getClassName() {
-        return "TabMyPostFragment";
-    }
-
     @Deprecated
     public TabMyPostFragment() {
         // 기본 생성자는 쓰지 말것 (new Instance 사용)

--- a/app/src/main/java/com/teame/boostcamp/myapplication/ui/tabsns/TabSNSFragment.java
+++ b/app/src/main/java/com/teame/boostcamp/myapplication/ui/tabsns/TabSNSFragment.java
@@ -18,11 +18,6 @@ public class TabSNSFragment extends BaseFragment<FragmentTabSnsBinding, TabSNSFr
         return null;
     }
 
-    @Override
-    protected String getClassName() {
-        return "TabSNSFragment";
-    }
-
     @Deprecated
     public TabSNSFragment() {
         // 기본 생성자는 쓰지 말것 (new Instance 사용)


### PR DESCRIPTION
## 개요
- 베이스 엑티비티 및 프레그먼트 Logging을 위해 사용했던 abstract 메소드 제거

## 작업내용
- 베이스 엑티비티 및 프레그먼트 abstract 메소드 제거
- Lifecycle을 위한 Log들이 사용했던 abstract getClassName() 을 getClass().getSimpleName()으로 변경
- 변경에 따른 Activity, Fragment abstract 구현 메소드 제거


참조 issue #35 

> protected abstract String getClassName();
> 
> 라이프사이클 Logging위해서 상속받는 모든 Activity와 Fragment에서 이를 명시적으로 하는 행위를 하는것보다
> 
> DLogUtil.i(getClass().getCanonicalName()+"::onStart");
> 
> DLogUtil.i(getClass().getSimpleName()+"::onStart");
> 
> 등으로 상속받은 클래스의 명칭을 찍어줄 수 있습니다.
> 
> 명시적으로 해당 클래스의 명을 입력하는 것은 불필요해 보이니 코드를 제거하는게 좋을거라 판단됩니다.

resolved #35 