### PR TITLE
feature/BCE-079-fix-review-write-reply-repo

### DIFF
--- a/app/src/main/java/com/teame/boostcamp/myapplication/model/repository/remote/GoodsDetailRemoteDataSource.java
+++ b/app/src/main/java/com/teame/boostcamp/myapplication/model/repository/remote/GoodsDetailRemoteDataSource.java
@@ -74,10 +74,11 @@ public class GoodsDetailRemoteDataSource implements GoodsDetailDataSource {
         Date nowDate = new Date(now);
         reply.setWriteDate(nowDate);
         PublishSubject<Reply> subject = PublishSubject.create();
-        String key = replyRef.getId();
-        Task saveReply = replyRef.document(key)
+        String key = replyRef.document(itemUid).collection(QUERY_GOODS_REPLY).document().getId();
+        Task saveReply = replyRef.document(itemUid)
                 .collection(QUERY_GOODS_REPLY)
-                .add(reply)
+                .document(key)
+                .set(reply)
                 .addOnSuccessListener(aVoid -> {
                     reply.setKey(key);
                     subject.onNext(reply);


### PR DESCRIPTION
## 개요
- 리뷰작성시 아이템 uid와 댓글 uid가 잘 사용되지 못함

## 작업사항
- 리뷰작성시 uid를 올바른 값이 들어가도록 수정

resolved #79 